### PR TITLE
Remove english possessive synonym

### DIFF
--- a/synonyms.txt
+++ b/synonyms.txt
@@ -9,7 +9,6 @@ and, &
 
 # explicit mappings
 tv => television, tv
-mowgli's => mowglis, mowgli's
 rmx => remix, rmx
 
 # non alphabet to alphabet


### PR DESCRIPTION
We manage english possissives with a Word Delimiter Filter. Setting synonyms manually is not needed anymore.